### PR TITLE
fix(orders): refine order update process and make fields optional

### DIFF
--- a/HotelMotorApi/Controllers/OrdersController.cs
+++ b/HotelMotorApi/Controllers/OrdersController.cs
@@ -75,7 +75,7 @@ namespace HotelMotorApi.Controllers
             }
         }
 
-        [HttpPut("{id}")]
+        [HttpPatch("{id}")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -116,7 +116,7 @@ namespace HotelMotorApi.Controllers
                 return BadRequest(new
                 {
                     status = 400,
-                    message = "Error al actualizar el orden",
+                    message = "Error al actualizar la orden",
                     error = ex.Message
                 });
             }

--- a/HotelMotorApi/Repositories/OrderRepository.cs
+++ b/HotelMotorApi/Repositories/OrderRepository.cs
@@ -40,18 +40,9 @@ namespace HotelMotorApi.Repositories
         }
         public async Task<Order?> UpdateAsync(Order order)
         {
-            var existingOrder = await GetByIdAsync(order.Id);
-            if (existingOrder == null)
-                return null;
-
-            existingOrder.Summary = order.Summary;
-            existingOrder.Status = order.Status;
-            existingOrder.TotalAmount = order.TotalAmount;
-            existingOrder.Vehicle = order.Vehicle;
-
-            _context.Orders.Update(existingOrder);
+            _context.Orders.Update(order);
             await _context.SaveChangesAsync();
-            return existingOrder;
+            return order;
         }
 
         public async Task<bool> DeleteAsync(int id)

--- a/HotelMotorShared/DTOs/OrderDTOs/OrderCreateDTO.cs
+++ b/HotelMotorShared/DTOs/OrderDTOs/OrderCreateDTO.cs
@@ -8,6 +8,10 @@ namespace HotelMotorShared.Dtos.OrderDTOs
         [Required(ErrorMessage = "El resumen de la orden es obligatorio.")]
         public required string Summary { get; set; }
         [Required(ErrorMessage = "El ID del vehículo es obligatorio.")]
-        public int VehicleId { get; set; } 
+        public int VehicleId { get; set; }
+
+        [Required(ErrorMessage = "El número de días para la fecha de vencimiento es obligatorio.")]
+        [Range(1, 365, ErrorMessage = "El número de días debe estar entre 1 y 365.")]
+        public int DueDateDays { get; set; }
     }
 }

--- a/HotelMotorShared/DTOs/OrderDTOs/OrderUpdateDTO.cs
+++ b/HotelMotorShared/DTOs/OrderDTOs/OrderUpdateDTO.cs
@@ -5,13 +5,11 @@ namespace HotelMotorShared.Dtos.OrderDTOs
 {
     public class OrderUpdateDTO
     {
-        [Required(ErrorMessage = "El resumen de la orden es obligatorio.")]
-        public required string Summary { get; set; }
-        
-        [Required(ErrorMessage = "El estado de la orden es obligatiorio")]
-        public OrderStatus Status { get; set; }
+        public string? Summary { get; set; }
 
-        [Required(ErrorMessage = "El ID del vehículo es obligatorio.")]
-        public int VehicleId { get; set; }
+        public OrderStatus? Status { get; set; }
+
+        [Range(1, 365, ErrorMessage = "El número de días debe estar entre 1 y 365.")]
+        public int? DueDateDays { get; set; }
     }
 }


### PR DESCRIPTION
- Make order update fields (summary, status, due date) optional instead of required
- Remove ability to change order vehicle after creation
- Add dynamic calculation of due date based on specified days
- Simplify repository update method to rely on EF Core change tracking
- Ensure proper null-checking for optional update fields
- Changed http method to patch in the controller for updating