### PR TITLE
feat(customers): add search endpoint by term

### DIFF
--- a/HotelMotorApi/Controllers/CustomersController.cs
+++ b/HotelMotorApi/Controllers/CustomersController.cs
@@ -182,5 +182,29 @@ namespace HotelMotorApi.Controllers
                 message = "Cliente eliminado exitosamente"
             });
         }
+
+        // GET: api/Customers/search?term=nombre_o_email
+        [HttpGet("search")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult<CustomerDto>> SearchCustomer([FromQuery] string term)
+        {
+            var customer = await _customerService.SearchOneAsync(term);
+            if (customer == null)
+            {
+                return NotFound(new
+                {
+                    status = 404,
+                    message = "Cliente no encontrado"
+                });
+            }
+
+            return Ok(new
+            {
+                status = 200,
+                message = "Cliente encontrado",
+                data = customer
+            });
+        }
     }
 }

--- a/HotelMotorApi/Interfaces/ICustomerRepository.cs
+++ b/HotelMotorApi/Interfaces/ICustomerRepository.cs
@@ -12,5 +12,6 @@ namespace HotelMotorApi.Interfaces
         Task<bool> DeleteAsync(int id);
         Task<bool> ExistsAsync(int id);
         Task<bool> EmailExistsAsync(string email);
+        Task<Customer?> SearchOneAsync(string searchTerm);
     }
 }

--- a/HotelMotorApi/Interfaces/ICustomerService.cs
+++ b/HotelMotorApi/Interfaces/ICustomerService.cs
@@ -9,5 +9,6 @@ namespace HotelMotorApi.Interfaces
         Task<CustomerDto> CreateAsync(CustomerCreateDto customerDto);
         Task<CustomerDto?> UpdateAsync(int id, CustomerUpdateDto customerDto);
         Task<bool> DeleteAsync(int id);
+        Task<CustomerDto?> SearchOneAsync(string searchTerm);
     }
 }

--- a/HotelMotorApi/Repositories/CustomerRepository.cs
+++ b/HotelMotorApi/Repositories/CustomerRepository.cs
@@ -78,5 +78,12 @@ namespace HotelMotorApi.Repositories
         {
             return await _context.Customers.AnyAsync(c => c.Email.ToLower() == email.ToLower());
         }
+
+        public async Task<Customer?> SearchOneAsync(string searchTerm)
+        {
+            return await _context.Customers
+                .Where(c => c.Name.Contains(searchTerm) || c.Email.Contains(searchTerm))
+                .FirstOrDefaultAsync();  // Devuelve solo el primer cliente que coincida
+        }
     }
 }

--- a/HotelMotorApi/Services/CustomerService.cs
+++ b/HotelMotorApi/Services/CustomerService.cs
@@ -59,5 +59,17 @@ namespace HotelMotorApi.Services
         {
             return await _customerRepository.DeleteAsync(id);
         }
+
+        public async Task<CustomerDto?> SearchOneAsync(string searchTerm)
+        {
+            var customer = await _customerRepository.SearchOneAsync(searchTerm);
+            if (customer == null)
+            {
+                return null;  // Si no se encuentra el cliente, retorna null
+            }
+
+            return _mapper.Map<CustomerDto>(customer);
+        }
+
     }
 }


### PR DESCRIPTION
- Implemented `SearchCustomer` endpoint to retrieve a customer by name or email.
- Integrated `ICustomerService` to handle business logic for searching customers.
- Updated `ICustomerRepository` to include a method for searching customers by term.
- Enhanced error handling to return a 404 status with an error message if the customer is not found.
- Mapped customer entities to `CustomerDto` for consistent API responses.
- Ensured the new endpoint returns a 200 status with a success message and customer data.