### PR TITLE
feat(auth): add admin role toggle and enforce admin UI restrictions

### DIFF
--- a/HotelMotorApi/Controllers/AuthController.cs
+++ b/HotelMotorApi/Controllers/AuthController.cs
@@ -35,5 +35,14 @@ namespace HotelMotorApi.Controllers
 
             return Ok(new { status = 200, message = "Inicio de sesión exitoso", data = result });
         }
+
+        [HttpPatch("{email}/alternate-admin")]
+        public async Task<IActionResult> AlternateAdmin(string email)
+        {
+            var result = await _authService.AlternateAdminAsync(email);
+            if (result == false)
+                return NotFound(new { status = 404, message = "Usuario no encontrado" });
+            return Ok(new { status = 200, message = "Rol de administrador alternado", data = result });
+        }
     }
 }

--- a/HotelMotorApi/Interfaces/IAuthService.cs
+++ b/HotelMotorApi/Interfaces/IAuthService.cs
@@ -6,5 +6,6 @@ namespace HotelMotorApi.Interfaces
     {
         Task<AuthResponseDto?> RegisterAsync(RegisterDto registerDto);
         Task<AuthResponseDto?> LoginAsync(LoginDto loginDto);
+        Task<Boolean> AlternateAdminAsync(string email);
     }
 }

--- a/HotelMotorApi/Interfaces/IUserRepository.cs
+++ b/HotelMotorApi/Interfaces/IUserRepository.cs
@@ -6,5 +6,6 @@ namespace HotelMotorApi.Interfaces
     {
         Task<User?> GetByEmailAsync(string email);
         Task<User> CreateUserAsync(User user);
+        Task<Boolean> AlternateAdminAsync(string email);
     }
 }

--- a/HotelMotorApi/Migrations/20250609223314_AddIsAdminColumnToUserTable.Designer.cs
+++ b/HotelMotorApi/Migrations/20250609223314_AddIsAdminColumnToUserTable.Designer.cs
@@ -4,6 +4,7 @@ using HotelMotorApi.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HotelMotorApi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250609223314_AddIsAdminColumnToUserTable")]
+    partial class AddIsAdminColumnToUserTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/HotelMotorApi/Migrations/20250609223314_AddIsAdminColumnToUserTable.cs
+++ b/HotelMotorApi/Migrations/20250609223314_AddIsAdminColumnToUserTable.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HotelMotorApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsAdminColumnToUserTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "isAdmin",
+                table: "Users",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "isAdmin",
+                table: "Users");
+        }
+    }
+}

--- a/HotelMotorApi/Repositories/UserRepository.cs
+++ b/HotelMotorApi/Repositories/UserRepository.cs
@@ -25,5 +25,16 @@ namespace HotelMotorApi.Repositories
             await _context.SaveChangesAsync();
             return user;
         }
+
+        public async Task<Boolean> AlternateAdminAsync(string email)
+        {
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.Email.ToLower() == email.ToLower());
+            if (user == null) return false;
+
+            user.isAdmin = !user.isAdmin;
+            _context.Users.Update(user);
+            await _context.SaveChangesAsync();
+            return true;
+        }
     }
 }

--- a/HotelMotorApi/Services/AuthService.cs
+++ b/HotelMotorApi/Services/AuthService.cs
@@ -29,7 +29,8 @@ namespace HotelMotorApi.Services
             {
                 Name = dto.Name,
                 Email = dto.Email,
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password)
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password),
+                isAdmin = false
             };
 
             await _userRepository.CreateUserAsync(user);
@@ -63,7 +64,8 @@ namespace HotelMotorApi.Services
             {
         new Claim(ClaimTypes.NameIdentifier, user.Id.ToString()),
         new Claim(ClaimTypes.Email, user.Email),
-        new Claim(ClaimTypes.Name, user.Name)
+        new Claim(ClaimTypes.Name, user.Name),
+        new Claim("IsAdmin", user.isAdmin.ToString().ToLower())
     };
 
             var token = new JwtSecurityToken(
@@ -83,5 +85,12 @@ namespace HotelMotorApi.Services
                 Name = user.Name
             };
         }
+
+        public async Task<Boolean> AlternateAdminAsync(string email)
+        {
+            var user = await _userRepository.GetByEmailAsync(email);
+            return await _userRepository.AlternateAdminAsync(email);
+        }
     }
+
 }

--- a/HotelMotorShared/Models/User.cs
+++ b/HotelMotorShared/Models/User.cs
@@ -10,5 +10,6 @@ namespace HotelMotorShared.Models
         public string Name { get; set; } = string.Empty;
         public string Email { get; set; } = string.Empty;
         public string PasswordHash { get; set; } = string.Empty;
+        public bool isAdmin { get; set; }
     }
 }

--- a/HotelMotorWeb/Layout/NavMenu.razor
+++ b/HotelMotorWeb/Layout/NavMenu.razor
@@ -12,13 +12,8 @@
 
             <!-- Título centrado -->
             <div class="position-absolute start-50 translate-middle-x">
-                <a class="navbar-text h2 text-white text-decoration-none m-0" href="/">HotelMotor</a>
+                <a class="navbar-text h2 text-white text-decoration-none m-0" href="/vehicles">HotelMotor</a>
             </div>
-
-            <NavLink href="grafico" Match="NavLinkMatch.All">
-                <span class="oi oi-graph" aria-hidden="true"></span> Gráfico
-            </NavLink>
-
 
             <!-- Menús desplegables y logout -->
             <AuthorizeView>
@@ -35,6 +30,8 @@
                             </ul>
                         </div>
 
+                        @if (isAdmin)
+                        {
                         <!-- Dropdown Servicios -->
                         <div class="dropdown">
                             <a class="nav-link dropdown-toggle text-bg-dark" href="#" id="serviciosDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -45,6 +42,7 @@
                                 <li><a class="dropdown-item" href="/services/create">Añadir nuevo servicio</a></li>
                             </ul>
                         </div>
+                        }
 
                         <!-- Cerrar sesión -->
                         <button class="btn btn-outline-light btn-sm" @onclick="Logout">Cerrar sesión</button>
@@ -60,6 +58,20 @@
 </nav>
 
 @code {
+    private bool isAdmin = false;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+		if (user.Identity?.IsAuthenticated == true)
+		{
+			var isAdminClaim = user.FindFirst(c => c.Type == "IsAdmin")?.Value;
+			isAdmin = isAdminClaim == "true" || isAdminClaim == "1";
+		}
+    }
+
     private async Task Logout()
     {
         await CustomAuthProvider.MarkUserAsLoggedOut();

--- a/HotelMotorWeb/Pages/Services/ServiceList.razor
+++ b/HotelMotorWeb/Pages/Services/ServiceList.razor
@@ -2,7 +2,12 @@
 @using HotelMotorShared.DTOs.ServiceDTOs
 @using HotelMotorWeb.Services.Services
 @using HotelMotorWeb.Components.Services
+@using Microsoft.AspNetCore.Components.Authorization
+@using HotelMotorWeb.Services.Auth
 @inject ServiceService ServiceService
+@inject AuthenticationStateProvider AuthProvider
+@inject CustomAuthProvider CustomAuthProvider
+@inject NavigationManager Navigation
 
 <h3 class="mb-4 fw-semibold">Lista de Servicios</h3>
 
@@ -38,6 +43,18 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        var authState = await AuthProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+
+		var isAdminClaim = user.FindFirst(c => c.Type == "IsAdmin")?.Value;
+        bool isAdmin = isAdminClaim == "true" || isAdminClaim == "1";
+
+		if (!isAdmin)
+		{
+			Navigation.NavigateTo("/vehicles", forceLoad: true);
+			return;
+		}
+
         await LoadServicesAsync();
     }
 


### PR DESCRIPTION
- Added AlternateAdmin endpoint in AuthController to toggle admin role via PATCH.
- Introduced AlternateAdminAsync method in IAuthService and IUserRepository interfaces.
- Implemented admin toggle logic in UserRepository and AuthService.
- Created migration AddIsAdminColumnToUserTable to store admin state in Users table.
- Updated JWT to include "IsAdmin" claim for client-side authorization.
- Modified NavMenu.razor to conditionally render admin menu items based on IsAdmin claim.
- Restricted access to /services list page to admin users via AuthProvider and NavigationManager redirect.