### PR TITLE
feat(word-export): generate and download Word file with service list

### DIFF
--- a/HotelMotorApi/HotelMotorApi.csproj
+++ b/HotelMotorApi/HotelMotorApi.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
+    <PackageReference Include="DocX" Version="4.0.25105.5786" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
     <PackageReference Include="MailKit" Version="4.12.1" />

--- a/HotelMotorApi/Modules/WordGenerator/Controller/WordController.cs
+++ b/HotelMotorApi/Modules/WordGenerator/Controller/WordController.cs
@@ -1,0 +1,36 @@
+﻿using HotelMotorApi.Modules.WordGenerator.Interfaces;
+using HotelMotorShared.DTOs.ServiceDTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HotelMotorApi.Modules.WordGenerator.Controller
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class WordController : ControllerBase
+    {
+        private readonly IWordService _wordService;
+
+        public WordController(IWordService wordService)
+        {
+            _wordService = wordService;
+        }
+
+        [HttpPost("generate-word")]
+        public async Task<IActionResult> GenerateServicesWordFile([FromBody] List<ServiceDto> services)
+        {
+            if (services == null || !services.Any())
+                return BadRequest("No se proporcionaron servicios.");
+
+            var fileBytes = await _wordService.GenerateFileWithServices(services);
+
+            if (fileBytes == null || fileBytes.Length == 0)
+                return StatusCode(500, "No se pudo generar el archivo Word.");
+
+            return File(
+                fileBytes,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "services.docx"
+            );
+        }
+    }
+}

--- a/HotelMotorApi/Modules/WordGenerator/Interfaces/IWordService.cs
+++ b/HotelMotorApi/Modules/WordGenerator/Interfaces/IWordService.cs
@@ -1,0 +1,9 @@
+﻿using HotelMotorShared.DTOs.ServiceDTOs;
+
+namespace HotelMotorApi.Modules.WordGenerator.Interfaces
+{
+    public interface IWordService
+    {
+        Task<byte[]> GenerateFileWithServices(List<ServiceDto> services);
+    }
+}

--- a/HotelMotorApi/Modules/WordGenerator/Services/WordService.cs
+++ b/HotelMotorApi/Modules/WordGenerator/Services/WordService.cs
@@ -1,0 +1,42 @@
+﻿using System.Globalization;
+using HotelMotorApi.Modules.WordGenerator.Interfaces;
+using HotelMotorShared.DTOs.ServiceDTOs;
+using Xceed.Document.NET;
+using Xceed.Words.NET;
+
+namespace HotelMotorApi.Modules.WordGenerator.Services
+{
+    public class WordService : IWordService
+    {
+        public async Task<byte[]> GenerateFileWithServices(List<ServiceDto> services)
+        {
+            using var ms = new MemoryStream();
+            using var doc = DocX.Create(ms);
+
+            doc.InsertParagraph("Listado de Servicios")
+                .FontSize(18)
+                .Bold()
+                .SpacingAfter(20);
+
+            var table = doc.AddTable(services.Count + 1, 3);
+            table.Design = TableDesign.ColorfulGridAccent1;
+
+            table.Rows[0].Cells[0].Paragraphs[0].Append("Nombre").Bold();
+            table.Rows[0].Cells[1].Paragraphs[0].Append("Descripción").Bold();
+            table.Rows[0].Cells[2].Paragraphs[0].Append("Precio").Bold();
+
+            for (int i = 0; i < services.Count; i++)
+            {
+                var s = services[i];
+                table.Rows[i + 1].Cells[0].Paragraphs[0].Append(s.Name);
+                table.Rows[i + 1].Cells[1].Paragraphs[0].Append(s.Description);
+                table.Rows[i + 1].Cells[2].Paragraphs[0].Append(s.Price.ToString("C", CultureInfo.CurrentCulture));
+            }
+
+            doc.InsertTable(table);
+            doc.Save();
+
+            return await Task.FromResult(ms.ToArray());
+        }
+    }
+}

--- a/HotelMotorApi/Program.cs
+++ b/HotelMotorApi/Program.cs
@@ -14,6 +14,8 @@ using System.Text;
 using HotelMotorShared.Models;
 using HotelMotorApi.Modules.EmailSender.Interfaces;
 using HotelMotorApi.Modules.EmailSender.Services;
+using HotelMotorApi.Modules.WordGenerator.Interfaces;
+using HotelMotorApi.Modules.WordGenerator.Services;
 
 DotNetEnv.Env.Load();
 
@@ -81,6 +83,7 @@ builder.Services.AddScoped<IVehiclesService, VehiclesService>();
 builder.Services.AddScoped<IServiceService, ServiceService>();
 builder.Services.AddScoped<IOrderService, OrderService>();
 builder.Services.AddScoped<IPdfService, PdfService>();
+builder.Services.AddScoped<IWordService, WordService>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 // Email Sender
 builder.Services.Configure<SmtpSettings>(options =>

--- a/HotelMotorWeb/Pages/Services/ServiceList.razor
+++ b/HotelMotorWeb/Pages/Services/ServiceList.razor
@@ -2,7 +2,10 @@
 @using HotelMotorShared.DTOs.ServiceDTOs
 @using HotelMotorWeb.Services.Services
 @using HotelMotorWeb.Components.Services
+@using HotelMotorWeb.Services.WordFiles
 @inject ServiceService ServiceService
+@inject WordService WordService
+@inject IJSRuntime JSRuntime;
 
 <h3 class="mb-4 fw-semibold">Lista de Servicios</h3>
 
@@ -12,6 +15,9 @@
 }
 else if (services != null && services.Any())
 {
+    <button class="btn btn-secondary mb-3" @onclick="DownloadServicesToWord">
+        Generar Servicios a Word
+    </button>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
         @foreach (var service in services)
         {
@@ -55,5 +61,15 @@ else
     private async Task HandleServiceDeleted(ServiceDto deletedService)
     {
         await LoadServicesAsync();
+    }
+
+    private async Task DownloadServicesToWord()
+    {
+        if (services is null) return;
+
+        var wordBytes = await WordService.GetWordWithServicesAsync(services);
+        var fileName = $"servicios_{DateTime.Now:yyyyMMdd_HHmmss}.docx";
+
+        await JSRuntime.InvokeVoidAsync("saveAsFile", fileName, Convert.ToBase64String(wordBytes));
     }
 }

--- a/HotelMotorWeb/Program.cs
+++ b/HotelMotorWeb/Program.cs
@@ -7,6 +7,7 @@ using HotelMotorWeb.Services.Orders;
 using HotelMotorWeb.Services.Pdfs;
 using HotelMotorWeb.Services.Services;
 using HotelMotorWeb.Services.Vehicles;
+using HotelMotorWeb.Services.WordFiles;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -30,6 +31,7 @@ builder.Services.AddScoped<VehiclesService>();
 builder.Services.AddScoped<OrderService>();
 builder.Services.AddScoped<ServiceService>();
 builder.Services.AddScoped<PdfService>();
+builder.Services.AddScoped<WordService>();
 builder.Services.AddScoped<AuthService>();
 
 await builder.Build().RunAsync();

--- a/HotelMotorWeb/Services/WordFiles/WordService.cs
+++ b/HotelMotorWeb/Services/WordFiles/WordService.cs
@@ -1,0 +1,22 @@
+﻿using System.Net.Http.Json;
+using HotelMotorShared.DTOs.ServiceDTOs;
+
+namespace HotelMotorWeb.Services.WordFiles
+{
+    public class WordService
+    {
+        private readonly HttpClient _httpClient;
+
+        public WordService(HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+        }
+
+        public async Task<byte[]> GetWordWithServicesAsync(IEnumerable<ServiceDto> services)
+        {
+            var response = await _httpClient.PostAsJsonAsync("word/generate-word", services);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadAsByteArrayAsync();
+        }
+    }
+}


### PR DESCRIPTION
- Installed DocX package to support Word file generation.
- Added IWordService interface and implemented WordService using DocX to build a services table.
- Created WordController with POST endpoint /api/word/generate-word to return .docx file.
- Registered IWordService in Program.cs.
- In Blazor frontend, added WordService to call API and retrieve the Word file.
- Implemented DownloadServicesToWord method in ServiceList.razor with JS interop to download the file.
- Injected and registered WordService in HotelMotorWeb Program.cs.
- Added saveAsFile JS function to trigger browser download of .docx file.